### PR TITLE
Feat/f-moveImageToCenter-1

### DIFF
--- a/src/components/SubWay/subwayLine2.vue
+++ b/src/components/SubWay/subwayLine2.vue
@@ -60,8 +60,6 @@ export default {
       startY: 0,
       translateX: 0,
       translateY: 0,
-      x: 0,
-      y: 0,
       rect: {},
     };
   },
@@ -70,6 +68,14 @@ export default {
       this.line2 = this.line2.map((item) => ({...item, open: false}));
     },
     mapClickHandler(event, key) {
+      const img = document.querySelector('.Line2-Image');
+      const targetX = event.target.coords.split(',')[0];
+      const targetY = event.target.coords.split(',')[1];
+      this.translateX =
+        ((340 - (targetX - 15)) / 390) * window.innerWidth * this.scale;
+      this.translateY =
+        ((280 - (targetY - 128)) / 844) * window.innerHeight * this.scale;
+      img.style.transform = `translate(${this.translateX}px, ${this.translateY}px) scale(${this.scale})`;
       this.line2 = this.line2.map((item) => ({...item, open: false}));
       const imageRect = this.$refs.image.getBoundingClientRect();
       this.rect = {
@@ -78,12 +84,14 @@ export default {
         width: imageRect.width,
         height: imageRect.height,
       };
-      this.x = event.clientX;
-      this.y = event.clientY;
       this.line2[key].open = true;
       this.$store.commit('setSelectStation', this.line2[key]);
       this.$store.commit('setBottomLockerCreated', true);
       this.$store.commit('setBottomLockerOpen', true);
+      this.$emit(
+        'translate',
+        `translate(${this.translateX}px, ${this.translateY}px)`,
+      );
     },
     imgHandleTouchStart(event) {
       const touch = event.touches[0];


### PR DESCRIPTION
화면 사이즈에 따른 계산이 추가로 필요함

<!-- // MR OPEN -->
<!-- // 구분 [종류] 내용 -->
<!-- // 구분에 해결할사람의 구분자를 넣어둠  -->
<!-- // ex) F가 B에게 요청해서 해결해야함 -> B [REQ] ***요청 -> B에서 해결 후 MR -->
<!-- B [MOD] /analyzer/launch API 변경 요청 -->
<!-- A [ISSUE] Ready시 CPU 사용량 100%되는 문제 -->

<!-- // Tag는 종류에 따라 작성 -->
<!-- // MR 템플릿 <http://gitlab.mkon/drivingex/drivingex-lm/-/issues/2> 참고 -->

<!-- 기존 -->
<!-- [ 내용 ] -->

<!-- 수정 -->
<!-- [ 내용 ]  -->

<!-- // 으로 MR을 보냄  -->

<!-- // MR Close -->
<!-- // Open한 MR에 Comment를 남긴 후 Close -->

## Docs

- [jira 이슈 링크](https://myemoji.atlassian.net/browse/POS-66?atlOrigin=eyJpIjoiMjg4NDk1YTlkYWM2NDM0ZWE5OGZjNmY5YTliNWMyYjAiLCJwIjoiaiJ9)

## Changes

- before :: 화면에 있는 역 클릭 시 그 위치에서 출발, 도착을 선택할 수 있는 버튼이 보여짐. 이때 하단에 있는 경우에는 버튼이 가려지는 문제가 발생한다.
- after :: 화면에 있는 역 클릭 시 클릭한 역의 위치가 화면 가운데로 이동

## Review Points

역 클릭 시 화면 가운데로 잘 이동하는지 확인

#### Problem

화면 사이즈에 따른 수정이 필요함

## Test Checklist

- [x] 390x844 크기에서는 동작
